### PR TITLE
Add preferMultipass INI option

### DIFF
--- a/include/SeasonManager.h
+++ b/include/SeasonManager.h
@@ -58,6 +58,8 @@ public:
 	SEASON GetSeasonOverride() const;
 	void   SetSeasonOverride(SEASON a_season);
 
+	bool PreferMultipass() const;
+
 protected:
 	using MONTH = RE::Calendar::Month;
 	using EventResult = RE::BSEventNotifyControl;
@@ -146,6 +148,8 @@ private:
 	SEASON lastSeason{ SEASON::kNone };
 
 	SEASON seasonOverride{ SEASON::kNone };
+
+	bool preferMultipass{ true };
 
 	std::atomic_bool isExterior{ false };
 

--- a/src/SeasonManager.cpp
+++ b/src/SeasonManager.cpp
@@ -148,6 +148,8 @@ void SeasonManager::LoadSettings()
 
 	logger::info("Season type is {}", stl::to_underlying(seasonType));
 
+	ini::get_value(ini, preferMultipass, "Settings", "Prefer Multipass", ";If true, multipass materials will be used where supported.\n;If false, single pass will be used instead.");
+
 	LoadMonthToSeasonMap(ini);
 
 	winter.LoadSettings(ini, true);
@@ -531,6 +533,11 @@ void SeasonManager::SetExterior(bool a_isExterior)
 SEASON SeasonManager::GetSeasonOverride() const
 {
 	return seasonOverride;
+}
+
+bool SeasonManager::PreferMultipass() const
+{
+	return preferMultipass;
 }
 
 void SeasonManager::SetSeasonOverride(SEASON a_season)

--- a/src/SnowSwap.cpp
+++ b/src/SnowSwap.cpp
@@ -153,6 +153,8 @@ namespace SnowSwap
 
 	SNOW_TYPE Manager::GetSnowType(const RE::TESObjectSTAT* a_static, RE::NiAVObject* a_node) const
 	{
+		const auto seasonManager = SeasonManager::GetSingleton();
+
 		using Flag = RE::BSShaderProperty::EShaderPropertyFlag;
 
 		if (GetWhitelistedForMultiPassSnow(a_static)) {
@@ -207,7 +209,7 @@ namespace SnowSwap
 			return RE::BSVisit::BSVisitControl::kContinue;
 		});
 
-		if (hasShape && !hasInvalidShape && hasLightingShaderProp && !hasAlphaProp) {
+		if (seasonManager->PreferMultipass() && hasShape && !hasInvalidShape && hasLightingShaderProp && !hasAlphaProp) {
 			return SNOW_TYPE::kMultiPass;
 		}
 


### PR DESCRIPTION
Both PBR in community shaders and complex material can do parallax and single pass snow together, and PBR actually requires it to look correct, so this PR adds an INI setting to allow the user to set whether multiPass should be preferred or not.

* If true (which is the default), the behavior is the same as before
* If false, single pass will be used always unless there is a whitelisted multipass set